### PR TITLE
Add environment variable to provide PATH overrides

### DIFF
--- a/pebble_tool/__init__.py
+++ b/pebble_tool/__init__.py
@@ -40,6 +40,9 @@ def run_tool(args=None):
         version_string += " (active SDK: v{})".format(sdk_version())
         # Add QEMU and others to PATH
         os.environ['PATH'] = "{}:{}".format(os.path.join(get_persist_dir(), "SDKs", sdk_version(), "toolchain", "bin"), os.environ['PATH'])
+        extra_path = os.environ['PEBBLE_EXTRA_PATH']
+        if extra_path:
+            os.environ['PATH'] = "{}:{}".format(extra_path, os.environ['PATH'])
     parser.add_argument("--version", action="version", version=version_string)
     register_children(parser)
     args = parser.parse_args(args)

--- a/pebble_tool/sdk/__init__.py
+++ b/pebble_tool/sdk/__init__.py
@@ -37,3 +37,6 @@ def get_sdk_persist_dir(platform, for_sdk_version=None):
 def add_tools_to_path():
     if sdk_version():
         os.environ['PATH'] = "{}:{}".format(os.path.join(get_persist_dir(), "SDKs", sdk_version(), "toolchain", "arm-none-eabi", "bin"), os.environ['PATH'])
+        extra_path = os.environ['PEBBLE_EXTRA_PATH']
+        if extra_path:
+            os.environ['PATH'] = "{}:{}".format(extra_path, os.environ['PATH'])


### PR DESCRIPTION
The new 4.4 SDK from Core Devices includes a precompiled qemu-pebble binary and ARM toolchain. While this is useful for most users, the binaries aren't usable on a NixOS system, due to the way NixOS handles dynamically-linked executables. To work around this, pebble.nix provides binaries built/patched specifically for NixOS, for pebble-tool to use. However, because the SDK binary paths are being appended to PATH, they get used first, overriding the versions pebble.nix supplies, breaking app building and the emulator when using pebble.nix on NixOS.

To resolve this, a check is added to see if the relevant tools already exist in PATH before adding the SDK-provided binaries. This way, any users that want to supply their own copies of qemu-pebble or the ARM toolchain for whatever reason can do so easily, without pebble-tool forcing them to use binaries provided by the SDK.