### PR TITLE
emulator.py: improve subprocess error handling (Py3.13) and correct PID check 

### DIFF
--- a/pebble_tool/sdk/emulator.py
+++ b/pebble_tool/sdk/emulator.py
@@ -476,4 +476,4 @@ class ManagedEmulatorTransport(WebsocketTransport):
         info = get_emulator_info(platform, version or sdk_manager.get_current_sdk())
         if info is None:
             return False
-        return cls._is_pid_running(info['pypkjs']['pid']) and cls._is_pid_running(info['pypkjs']['pid'])
+        return cls._is_pid_running(info['pypkjs']['pid']) and cls._is_pid_running(info['qemu']['pid'])


### PR DESCRIPTION
### fix: subprocess error handling on py3.13 (text outputs)
- Python 3.13 with text=True returns str in CalledProcessError.output/.stdout. Calling .decode() raised:
   - AttributeError: 'str' object has no attribute 'decode'
- Changes:
   - Add a small helper to coerce subprocess outputs (bytes or str) to text safely.
   - Use text=True, encoding='utf-8', errors='replace' when capturing command output.
   - Read e.stdout first (if present), falling back to e.output.
   - Apply consistently to _spawn_qemu, _spawn_websockify, and _spawn_pypkjs.
   
Error that was occurring:
<details>
<summary>Click to expand</summary>

```shell
$ pebble build && pebble install --emulator diorite

# trimmed for brevity

[90/90] app_bundle:  -> build/Helios.pbw
Waf: Leaving directory `/var/home/sidpatchy/Downloads/Helios/build'
'build' finished successfully (0.887s)
Traceback (most recent call last):
  File "/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/lib64/python3.13/site-packages/pebble_tool/sdk/emulator.py", line 413, in _spawn_pypkjs
    subprocess.check_output(command, stderr=subprocess.STDOUT, text=True)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/subprocess.py", line 472, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               **kwargs).stdout
               ^^^^^^^^^
  File "/usr/lib64/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/bin/python', '-m', 'pypkjs', '--qemu', 'localhost:60635', '--port', '43387', '--persist', '/var/home/sidpatchy/.pebble-sdk/4.5/aplite', '--layout', '/var/home/sidpatchy/.pebble-sdk/SDKs/4.5/sdk-core/pebble/aplite/qemu/layouts.json', '--debug']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/home/sidpatchy/.local/bin/pebble", line 10, in <module>
    sys.exit(run_tool())
             ~~~~~~~~^^
  File "/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/lib64/python3.13/site-packages/pebble_tool/__init__.py", line 57, in run_tool
    args.func(args)
    ~~~~~~~~~^^^^^^
  File "/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/lib64/python3.13/site-packages/pebble_tool/commands/base.py", line 47, in <lambda>
    parser.set_defaults(func=lambda x: cls()(x))
                                       ~~~~~^^^
  File "/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/lib64/python3.13/site-packages/pebble_tool/commands/install.py", line 23, in __call__
    super(InstallCommand, self).__call__(args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/lib64/python3.13/site-packages/pebble_tool/commands/base.py", line 104, in __call__
    self.pebble = self._connect(args)
                  ~~~~~~~~~~~~~^^^^^^
  File "/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/lib64/python3.13/site-packages/pebble_tool/commands/base.py", line 122, in _connect
    connection.connect()
    ~~~~~~~~~~~~~~~~~~^^
  File "/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/lib64/python3.13/site-packages/libpebble2/communication/__init__.py", line 56, in connect
    self.transport.connect()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/lib64/python3.13/site-packages/pebble_tool/sdk/emulator.py", line 99, in connect
    self._spawn_processes()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/lib64/python3.13/site-packages/pebble_tool/sdk/emulator.py", line 202, in _spawn_processes
    self._spawn_pypkjs()
    ~~~~~~~~~~~~~~~~~~^^
  File "/var/home/sidpatchy/.local/share/uv/tools/pebble-tool/lib64/python3.13/site-packages/pebble_tool/sdk/emulator.py", line 415, in _spawn_pypkjs
    raise MissingEmulatorError("Couldn't launch pypkjs:\n{}".format(e.output.decode('utf-8').strip()))
                                                                    ^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```

</details>

### fix: check qemu pid in is_emulator_alive instead of pypkjs twice
- Previously: is_emulator_alive returned the logical AND of the pypkjs PID with itself, which could report “alive” even if qemu had exited.
- Now: checks both pypkjs and qemu PIDs.
