### PR TITLE
emu-app-config: allowing codespace/devcontainer execution

### DIFF
--- a/pebble_tool/commands/emucontrol.py
+++ b/pebble_tool/commands/emucontrol.py
@@ -102,6 +102,16 @@ class EmuAppConfigCommand(PebbleCommand):
 
     def __call__(self, args):
         super(EmuAppConfigCommand, self).__call__(args)
+
+        # To use this command in a Github codespace, we need the user browser to reach the
+        # open port on his github codespace virtual machine instead of 'localhost' when user press
+        # the submit button, as this script will be listening from the codespace virtual machine.
+        #
+        # To achieve this, must be provided the following arguments:
+        #   - '--address {addres}': address to use when sending config data, instead of 'localhost'
+        #   - '--port {port}': port to use to retrieve config data
+        browser = BrowserController()
+
         try:
             if isinstance(self.pebble.transport, ManagedEmulatorTransport):
                 self.pebble.transport.send_packet(WebSocketPhonesimAppConfig(config=AppConfigSetup()),
@@ -117,7 +127,12 @@ class EmuAppConfigCommand(PebbleCommand):
         else:
             config_url = response.config.data
 
-        browser = BrowserController()
+        if args.address:
+            browser.configure_address(args.address)
+
+        if args.port:
+            browser.configure_port(args.port)
+
         browser.open_config_page(config_url, self.handle_config_close)
 
     def handle_config_close(self, query):
@@ -132,6 +147,8 @@ class EmuAppConfigCommand(PebbleCommand):
     def add_parser(cls, parser):
         parser = super(EmuAppConfigCommand, cls).add_parser(parser)
         parser.add_argument('--file', help="Name of local file to use for settings page in lieu of URL specified in JS")
+        parser.add_argument('--address', help="Provide the return address, instead of using localhost")
+        parser.add_argument('--port', help="Use the specified port instead of creating one")
         return parser
 
 

--- a/pebble_tool/util/browser.py
+++ b/pebble_tool/util/browser.py
@@ -17,12 +17,24 @@ logger = logging.getLogger("pebble_tool.util.browser")
 class BrowserController(object):
     def __init__(self):
         self.port = None
+        self.address = None
+    
+    def configure_port(self, port):
+        self.port = port
+
+    def configure_address(self, address):
+        self.address = address
 
     def open_config_page(self, url, callback):
-        self.port = port = self._choose_port()
-        url = self.url_append_params(url, {'return_to': 'http://localhost:{}/close?'.format(port)})
+        if self.port == None:
+            self.port = self._choose_port()
+        host = 'http://localhost:{}/close?'.format(self.port)
+        if self.address:
+            host = '{}/close?'.format(self.address)
+        url = self.url_append_params(url, {'return_to': host})
         webbrowser.open_new(url)
-        self.serve_page(port, callback)
+        self.serve_page(int(self.port), callback)
+        self.__init__()
 
     def serve_page(self, port, callback):
         # This is an array so AppConfigHandler doesn't create an instance variable when trying to set the state to False


### PR DESCRIPTION
Implementing a fix to the emu-app-config execution in a codespace with the VSCode extension by providing two arguments representing the port and the return address.

The VSCode extension will have to make the provided port public before executing the command for this to work. PR incoming to the VSCode extension.

Command will behave as usual if those two arguments are ignored.