### PR TITLE
Fix repeated "No SDK installed" messages during sdk install

### DIFF
--- a/pebble_tool/sdk/manager.py
+++ b/pebble_tool/sdk/manager.py
@@ -28,8 +28,10 @@ def get_pebble_platforms(sdk_path=None):
     """Get platforms from the installed SDK, with fallback to hardcoded list."""
     try:
         if sdk_path is None:
-            from pebble_tool.sdk import sdk_path as get_sdk_path
-            sdk_path = get_sdk_path()
+            from pebble_tool.sdk import sdk_manager
+            sdk_path = sdk_manager.current_path
+            if sdk_path is None:
+                return _FALLBACK_PLATFORMS
 
         # Try standard SDK structure: <sdk-core>/pebble/common/tools/pebble_sdk_platform.py
         platform_file = os.path.join(sdk_path, 'pebble', 'common', 'tools', 'pebble_sdk_platform.py')


### PR DESCRIPTION
## Summary

- Fixes issue where `pebble sdk install latest` prints "No SDK installed; installing the latest one..." repeatedly (~20 times) before actually installing

## Root Cause

`get_pebble_platforms()` was called during argument parser setup for each `PebbleCommand` subclass (about 20 commands). It called `sdk_path()` which triggers auto-install when no SDK is present, causing the repeated messages.

## Fix

Use `sdk_manager.current_path` directly and return fallback platforms immediately when no SDK is installed, avoiding the auto-install side effect.