### PR TITLE
Removes hatch reference to Python 2 alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,6 @@ Homepage = "https://github.com/coredevices/pebble-tool"
 [tool.hatch.build.targets.wheel]
 packages = ["pebble_tool"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"pebble_tool/commands/sdk/python" = "pebble_tool/commands/sdk/python"
-
 [tool.hatch.build.targets.sdist]
 include = [
     "/pebble_tool",


### PR DESCRIPTION
Removes a reference to the Python 2 aliasing that I missed in #29. Including these lines causes `uv` to error out on `uv run pebble.py`. Apologies for not catching this sooner/in the original PR.