### PR TITLE
Fix argparse help output broken by bb1e7a8617

### DIFF
--- a/pebble_tool/commands/base.py
+++ b/pebble_tool/commands/base.py
@@ -80,12 +80,17 @@ class PebbleCommand(BaseCommand):
     def _shared_parser(cls):
         parser = argparse.ArgumentParser(add_help=False)
         handlers = cls.valid_connection_handlers()
-        # Having a group inside a mutually exclusive group breaks --help unless there are is
-        # something for it to be mutually exlusive with.
+
+        # A group can only be mutually exclusive if it contains at least one command,
+        # else argparse raises an error during --help generation.
+        # Commands in sub-groups do not count, and mutual exclusivity is not applied to them.
+        # Therefore this implementation assumes that `handlers` always contains at least one handler
+        # whose `add_argument_handler()` adds a command directly to `group`.
         if len(handlers) > 1:
             group = parser.add_mutually_exclusive_group()
         else:
             group = parser
+
         for handler_impl in handlers:
             handler_impl.add_argument_handler(group)
         return super(PebbleCommand, cls)._shared_parser() + [parser]
@@ -170,6 +175,9 @@ class PebbleTransportConfiguration(with_metaclass(SelfRegisteringTransportConfig
 
     @classmethod
     def add_argument_handler(cls):
+        """Note: this method must add at least one command directly to `cls`, not only a group,
+        because `cls` can be a mutually exclusive group (see PebbleCommand._shared_parser).
+        """
         raise NotImplementedError
 
     @classmethod
@@ -274,14 +282,15 @@ class PebbleTransportQemu(PebbleTransportConfiguration):
 
     @classmethod
     def add_argument_handler(cls, parser):
-        qemu_group = parser.add_argument_group()
-        qemu_group.add_argument('--qemu', nargs='?', const='localhost:12344', metavar='host',
+        # Ungrouped to apply mutual exclusivity; see PebbleCommand._shared_parser()
+        parser.add_argument('--qemu', nargs='?', const='localhost:12344', metavar='host',
                             help="Use this option to connect directly to a QEMU instance. "
                                  "Equivalent to PEBBLE_QEMU.")
+        qemu_group = parser.add_argument_group()
         qemu_group.add_argument('--pypkjs', action='store_true',
                             help="When using --qemu, also spawn pypkjs. Requires --platform.")
         qemu_group.add_argument('--platform', type=str, choices=get_pebble_platforms(),
-                            help="Platform for pypkjs when using --qemu --pypkjs.")
+                                help="When using --qemu --pypkjs, specify the platform.")
 
 
 class PebbleTransportCloudPebble(PebbleTransportConfiguration):
@@ -347,12 +356,13 @@ class PebbleTransportEmulator(PebbleTransportConfiguration):
 
     @classmethod
     def add_argument_handler(cls, parser):
+        # Ungrouped to apply mutual exclusivity; see PebbleCommand._shared_parser()
+        parser.add_argument('--emulator', type=str, help="Launch an emulator. Equivalent to PEBBLE_EMULATOR.",
+                            choices=get_pebble_platforms())
         emu_group = parser.add_argument_group()
-        emu_group.add_argument('--emulator', type=str, help="Launch an emulator. Equivalent to PEBBLE_EMULATOR.",
-                           choices=get_pebble_platforms())
-        emu_group.add_argument('--sdk', type=str, help="SDK version to launch. Defaults to the active SDK"
-                                                   " (currently {})".format(sdk_version()))
-        emu_group.add_argument('--vnc', action='store_true', help="Enable VNC server for the emulator")
+        emu_group.add_argument('--sdk', type=str, help="When using --emulator, SDK version to launch."
+                               " Defaults to the active SDK (currently {})".format(sdk_version()))
+        emu_group.add_argument('--vnc', action='store_true', help="When using --emulator, enable VNC server.")
 
 def register_children(parser):
     subparsers = parser.add_subparsers(title="command")


### PR DESCRIPTION
Fixes the crashes that prevent help from ever being generated for emu commands. For example:

```
> pebble emu-button
Traceback (most recent call last):
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 1965, in _parse_known_args2
    namespace, args = self._parse_known_args(args, namespace, intermixed)
                      ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 2262, in _parse_known_args
    raise ArgumentError(None, _('the following arguments are required: %s') %
               ', '.join(required_actions))
argparse.ArgumentError: the following arguments are required: action

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ajh/.local/bin/pebble", line 10, in <module>
    sys.exit(run_tool())
             ~~~~~~~~^^
  File "/home/ajh/.local/share/uv/tools/pebble-tool/lib/python3.13/site-packages/pebble_tool/__init__.py", line 54, in run_tool
    args = parser.parse_args(args)
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 1926, in parse_args
    args, argv = self.parse_known_args(args, namespace)
                 ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 1936, in parse_known_args
    return self._parse_known_args2(args, namespace, intermixed=False)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 1965, in _parse_known_args2
    namespace, args = self._parse_known_args(args, namespace, intermixed)
                      ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 2220, in _parse_known_args
    stop_index = consume_positionals(start_index)
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 2172, in consume_positionals
    take_action(action, args)
    ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 2041, in take_action
    action(self, namespace, argument_values, option_string)
    ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 1286, in __call__
    subnamespace, arg_strings = subparser.parse_known_args(arg_strings, None)
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 1936, in parse_known_args
    return self._parse_known_args2(args, namespace, intermixed=False)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 1967, in _parse_known_args2
    self.error(str(err))
    ~~~~~~~~~~^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 2684, in error
    self.print_usage(_sys.stderr)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 2651, in print_usage
    self._print_message(self.format_usage(), file)
                        ~~~~~~~~~~~~~~~~~^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 2616, in format_usage
    return formatter.format_help()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 287, in format_help
    help = self._root_section.format_help()
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 216, in format_help
    item_help = join([func(*args) for func, args in self.items])
                      ~~~~^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 325, in _format_usage
    action_usage = format(optionals + positionals, groups)
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 393, in _format_actions_usage
    return ' '.join(self._get_actions_usage_parts(actions, groups))
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 396, in _get_actions_usage_parts
    parts, _ = self._get_actions_usage_parts_with_split(actions, groups)
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/argparse.py", line 412, in _get_actions_usage_parts_with_split
    raise ValueError(f'empty group {group}')
ValueError: empty group <argparse._MutuallyExclusiveGroup object at 0x70247493b850>
```