### PR TITLE
Add send-app-message command

### DIFF
--- a/pebble_tool/__init__.py
+++ b/pebble_tool/__init__.py
@@ -30,7 +30,7 @@ from .commands.sdk.project import build
 
 from .commands.base import register_children
 from .commands import (install, logs, screenshot, timeline, emucontrol, ping, account, repl,
-                       transcription_server, data_logging, publish, firmware)
+                       transcription_server, data_logging, publish, firmware, appmessage)
 from .commands.sdk import create, emulator
 from .commands.sdk.project import package, analyse_size, convert, debug
 

--- a/pebble_tool/commands/appmessage.py
+++ b/pebble_tool/commands/appmessage.py
@@ -1,0 +1,149 @@
+import uuid as uuid_module
+
+from libpebble2.services.appmessage import AppMessageService, Int32, Uint32, CString, ByteArray
+
+from .base import PebbleCommand
+from ..exceptions import ToolError, PebbleProjectException
+from ..sdk.project import PebbleProject
+
+
+class SendAppMessageCommand(PebbleCommand):
+    """Sends an App Message key-value dictionary to the running watchapp."""
+    command = 'send-app-message'
+    valid_connections = {'emulator', 'qemu', 'phone', 'serial', 'cloudpebble'}
+
+    @classmethod
+    def _parse_key_value(cls, entry, flag_name):
+        """Parse KEY=VALUE entry, validate key is integer. Return (int_key, str_value)."""
+        try:
+            key_str, value_str = entry.split('=', 1)
+        except ValueError:
+            raise ToolError(
+                "Invalid --{} entry '{}'. Expected format: KEY=VALUE".format(flag_name, entry)
+            )
+
+        try:
+            key = int(key_str)
+        except ValueError:
+            raise ToolError(
+                "Invalid key '{}' in --{} entry '{}'. Key must be an integer.".format(key_str, flag_name, entry)
+            )
+
+        return key, value_str
+
+    @classmethod
+    def _parse_bytes_file(cls, entry):
+        """Parse a KEY=FILEPATH entry, read the file, and return (int_key, ByteArray)."""
+        try:
+            key_str, filepath = entry.split('=', 1)
+        except ValueError:
+            raise ToolError(
+                "Invalid --bytes-file entry '{}'. Expected format: KEY=FILEPATH".format(entry)
+            )
+
+        try:
+            key = int(key_str)
+        except ValueError:
+            raise ToolError(
+                "Invalid key '{}' in --bytes-file entry '{}'. Key must be an integer.".format(key_str, entry)
+            )
+
+        try:
+            with open(filepath, 'rb') as fh:
+                data = fh.read()
+        except OSError as e:
+            raise ToolError("Could not read bytes file '{}': {}".format(filepath, e))
+
+        return key, ByteArray(data)
+
+    def __call__(self, args):
+        super(SendAppMessageCommand, self).__call__(args)
+        int_entries = args.int_entries or []
+        uint_entries = args.uint_entries or []
+        string_entries = args.string_entries or []
+        bytes_entries = args.bytes_entries or []
+        bytes_files = args.bytes_file or []
+
+        if not any([int_entries, uint_entries, string_entries, bytes_entries, bytes_files]):
+            raise ToolError("At least one typed flag (--int, --uint, --string, --bytes) or --bytes-file entry is required.")
+
+        dictionary = {}
+
+        for entry in int_entries:
+            key, value_str = self._parse_key_value(entry, 'int')
+            try:
+                dictionary[key] = Int32(int(value_str))
+            except ValueError:
+                raise ToolError("Invalid int value '{}' in --int entry '{}'.".format(value_str, entry))
+
+        for entry in uint_entries:
+            key, value_str = self._parse_key_value(entry, 'uint')
+            try:
+                dictionary[key] = Uint32(int(value_str))
+            except ValueError:
+                raise ToolError("Invalid uint value '{}' in --uint entry '{}'.".format(value_str, entry))
+
+        for entry in string_entries:
+            key, value_str = self._parse_key_value(entry, 'string')
+            dictionary[key] = CString(value_str)
+
+        for entry in bytes_entries:
+            key, value_str = self._parse_key_value(entry, 'bytes')
+            try:
+                dictionary[key] = ByteArray(bytes.fromhex(value_str))
+            except ValueError:
+                raise ToolError("Invalid hex bytes value '{}' in --bytes entry '{}'.".format(value_str, entry))
+
+        for entry in bytes_files:
+            key, typed_value = self._parse_bytes_file(entry)
+            dictionary[key] = typed_value
+
+        if args.app_uuid is not None:
+            app_uuid = args.app_uuid
+        else:
+            try:
+                app_uuid = str(PebbleProject().uuid)
+            except PebbleProjectException:
+                raise ToolError("You must either use this command from a pebble project or specify --app-uuid.")
+
+        try:
+            target_uuid = uuid_module.UUID(app_uuid)
+        except ValueError:
+            raise ToolError("Invalid UUID format: '{}'".format(app_uuid))
+
+        service = AppMessageService(self.pebble)
+        try:
+            service.send_message(target_uuid, dictionary)
+        except IOError as e:
+            raise ToolError(str(e))
+        finally:
+            service.shutdown()
+
+    @classmethod
+    def add_parser(cls, parser):
+        parser = super(SendAppMessageCommand, cls).add_parser(parser)
+        parser.add_argument(
+            '--int', nargs='+', dest='int_entries', metavar='KEY=VALUE',
+            help="Send a signed 32-bit integer, e.g. --int 1=42 2=-10"
+        )
+        parser.add_argument(
+            '--uint', nargs='+', dest='uint_entries', metavar='KEY=VALUE',
+            help="Send an unsigned 32-bit integer, e.g. --uint 1=100"
+        )
+        parser.add_argument(
+            '--string', nargs='+', dest='string_entries', metavar='KEY=VALUE',
+            help="Send a C string, e.g. --string 2=hello"
+        )
+        parser.add_argument(
+            '--bytes', nargs='+', dest='bytes_entries', metavar='KEY=HEXVALUE',
+            help="Send raw bytes as hex, e.g. --bytes 3=DEADBEEF"
+        )
+        parser.add_argument(
+            '--bytes-file', nargs='+', metavar='KEY=FILEPATH',
+            help="Send raw bytes from a file, e.g. --bytes-file 4=data.bin"
+        )
+        parser.add_argument(
+            '--app-uuid', type=str, default=None,
+            help="UUID of the target watchapp."
+        )
+        return parser

--- a/tests/test_send_appmessage_command.py
+++ b/tests/test_send_appmessage_command.py
@@ -1,0 +1,145 @@
+"""
+Tests for the SendAppMessageCommand.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from pebble_tool.commands.appmessage import SendAppMessageCommand
+from pebble_tool.exceptions import ToolError
+from libpebble2.services.appmessage import Int32, Uint32, CString, ByteArray
+
+
+class TestParseKeyValue:
+    """Tests for SendAppMessageCommand._parse_key_value"""
+
+    def test_decimal_key(self):
+        key, value = SendAppMessageCommand._parse_key_value("1=42", "int")
+        assert key == 1
+        assert value == "42"
+
+    def test_value_with_equals(self):
+        key, value = SendAppMessageCommand._parse_key_value("5=foo=bar", "string")
+        assert key == 5
+        assert value == "foo=bar"
+
+    def test_empty_value(self):
+        key, value = SendAppMessageCommand._parse_key_value("1=", "string")
+        assert key == 1
+        assert value == ""
+
+    def test_invalid_missing_equals(self):
+        with pytest.raises(ToolError, match="Invalid --int entry"):
+            SendAppMessageCommand._parse_key_value("1", "int")
+
+    def test_invalid_key(self):
+        with pytest.raises(ToolError, match="Invalid key"):
+            SendAppMessageCommand._parse_key_value("notanint=42", "int")
+
+    def test_flag_name_in_error(self):
+        with pytest.raises(ToolError, match="--uint"):
+            SendAppMessageCommand._parse_key_value("bad=value", "uint")
+
+
+class TestIntConversion:
+    """Tests for --int flag value conversion logic in __call__"""
+
+    def test_decimal(self):
+        key, value_str = SendAppMessageCommand._parse_key_value("1=42", "int")
+        assert Int32(int(value_str)).value == 42
+
+    def test_negative(self):
+        key, value_str = SendAppMessageCommand._parse_key_value("1=-10", "int")
+        assert Int32(int(value_str)).value == -10
+
+    def test_invalid_value(self):
+        key, value_str = SendAppMessageCommand._parse_key_value("1=notanumber", "int")
+        with pytest.raises(ValueError):
+            int(value_str)
+
+
+class TestUintConversion:
+    """Tests for --uint flag value conversion logic"""
+
+    def test_decimal(self):
+        key, value_str = SendAppMessageCommand._parse_key_value("3=100", "uint")
+        assert Uint32(int(value_str)).value == 100
+
+    def test_invalid_value(self):
+        key, value_str = SendAppMessageCommand._parse_key_value("1=notanumber", "uint")
+        with pytest.raises(ValueError):
+            int(value_str)
+
+
+class TestStringConversion:
+    """Tests for --string flag value conversion logic"""
+
+    def test_simple(self):
+        key, value_str = SendAppMessageCommand._parse_key_value("2=hello", "string")
+        assert CString(value_str).value == "hello"
+
+    def test_empty(self):
+        key, value_str = SendAppMessageCommand._parse_key_value("2=", "string")
+        assert CString(value_str).value == ""
+
+
+class TestBytesConversion:
+    """Tests for --bytes flag value conversion logic"""
+
+    def test_hex_uppercase(self):
+        key, value_str = SendAppMessageCommand._parse_key_value("4=DEADBEEF", "bytes")
+        assert ByteArray(bytes.fromhex(value_str)).value == bytes.fromhex("DEADBEEF")
+
+    def test_hex_lowercase(self):
+        key, value_str = SendAppMessageCommand._parse_key_value("4=deadbeef", "bytes")
+        assert ByteArray(bytes.fromhex(value_str)).value == b'\xde\xad\xbe\xef'
+
+    def test_invalid_value(self):
+        key, value_str = SendAppMessageCommand._parse_key_value("1=ZZZZ", "bytes")
+        with pytest.raises(ValueError):
+            bytes.fromhex(value_str)
+
+
+class TestParseBytesFile:
+    """Tests for SendAppMessageCommand._parse_bytes_file"""
+
+    def test_reads_file_contents(self):
+        data = b'\xDE\xAD\xBE\xEF'
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(data)
+            path = f.name
+        try:
+            key, value = SendAppMessageCommand._parse_bytes_file("4={}".format(path))
+            assert key == 4
+            assert isinstance(value, ByteArray)
+            assert value.value == data
+        finally:
+            os.unlink(path)
+
+    def test_filepath_with_equals(self):
+        """File paths containing '=' should be handled correctly."""
+        data = b'\x00'
+        with tempfile.NamedTemporaryFile(suffix='=test.bin', delete=False) as f:
+            f.write(data)
+            path = f.name
+        try:
+            key, value = SendAppMessageCommand._parse_bytes_file("1={}".format(path))
+            assert key == 1
+            assert value.value == data
+        finally:
+            os.unlink(path)
+
+    def test_invalid_missing_equals(self):
+        with pytest.raises(ToolError, match="Invalid --bytes-file entry"):
+            SendAppMessageCommand._parse_bytes_file("1")
+
+    def test_invalid_key(self):
+        with pytest.raises(ToolError, match="Invalid key"):
+            SendAppMessageCommand._parse_bytes_file("notanint=/some/path")
+
+    def test_file_not_found(self):
+        with pytest.raises(ToolError, match="Could not read bytes file"):
+            SendAppMessageCommand._parse_bytes_file("1=/nonexistent/path/file.bin")


### PR DESCRIPTION
Adds a new `pebble send-app-message` CLI command for sending AppMessage key-value dictionaries to a running watchapp. I found myself stuck trying to debug a watch app in the emulator that relied on sending keys from the companion app. So I added this functionality to speed up my own development and debugging.

Supported value types:
- `--int KEY=VALUE` — signed 32-bit integer
- `--uint KEY=VALUE` — unsigned 32-bit integer
- `--string KEY=VALUE` — C string
- `--bytes KEY=HEX` — raw bytes from a hex string
- `--bytes-file KEY=PATH` — raw bytes from a file
- `--app-uuid UUID` — target app (defaults to the UUID of the current pebble project)

Keys are decimal integers, matching the values generated for `messageKeys` in `package.json`.

### Example

```bash
# Send one int message for key 1
pebble send-app-message --int 1=42

# Send one string message for key 2
pebble send-app-message --int 2=hello

# Send to particular emulator
pebble send-app-message --int 2=hello --emulator emery

# Send to running watchapp via cloudpebble
pebble send-app-message --int 2=hello --phone

# Send multiple messages in one command
pebble send-app-message \
  --int 1=42 \
  --string 2=hello \
  --bytes 3=DEADBEEF \
  --bytes-file 4=payload.bin
```

Run from inside a pebble project, or pass `--app-uuid <uuid>` to target an arbitrary app.