### PR TITLE
Add catch for JSON decode errors

### DIFF
--- a/pebble_tool/util/config.py
+++ b/pebble_tool/util/config.py
@@ -17,6 +17,8 @@ class Config(object):
                 self.content = json.load(f)
         except IOError:
             self.content = {}
+        except json.JSONDecodeError:
+            self.content = {}
 
     def save(self):
         with open(self.path, 'w') as f:


### PR DESCRIPTION
I've run into a situation where the settings.json file was totally blank