### PR TITLE
Support long urls (i.e. large Clay configs) in emu-app-config

### DIFF
--- a/pebble_tool/util/browser.py
+++ b/pebble_tool/util/browser.py
@@ -1,13 +1,16 @@
 
 
-from six.moves import BaseHTTPServer
+import contextlib
 import logging
 import os
-import pyqrcode
 import socket
+import tempfile
 import time
-from six.moves.urllib import parse as urlparse
 import webbrowser
+
+import pyqrcode
+from six.moves import BaseHTTPServer
+from six.moves.urllib import parse as urlparse
 
 from .phone_sensor import SENSOR_PAGE_HTML
 
@@ -21,8 +24,24 @@ class BrowserController(object):
     def open_config_page(self, url, callback):
         self.port = port = self._choose_port()
         url = self.url_append_params(url, {'return_to': 'http://localhost:{}/close?'.format(port)})
-        webbrowser.open_new(url)
-        self.serve_page(port, callback)
+
+        if url.startswith('file'):
+            webbrowser.open_new(url)
+            self.serve_page(port, callback)
+        else:
+            # The URL argument length limit can quickly be exceeded by a Clay config page
+            # so instead of providing the URL directly, write it to a temporary file.
+            # Default Ubuntu firefox installation can't access /tmp
+            # so place the temporary file in the user's home directory.
+            with tempfile.NamedTemporaryFile(dir=os.path.expanduser("~"),
+                                             delete_on_close=False,
+                                             prefix="pebble-tool-emu-app-config-") as temp:
+                with open(temp.name, mode="w") as f:
+                    f.write(f'<head><meta http-equiv="refresh" content="0;URL={url}"></head>')
+                tempfile_url = f"file://{temp.name}"
+
+                webbrowser.open_new(tempfile_url)
+                self.serve_page(port, callback)
 
     def serve_page(self, port, callback):
         # This is an array so AppConfigHandler doesn't create an instance variable when trying to set the state to False


### PR DESCRIPTION
I added one more config option to my moderately-sized (17 messageKeys) Clay config page, and was met with the following error when running `emu-app-config`:
```
> pebble emu-app-config --emulator emery
[...] (see bottom of this post for the full error)
OSError: [Errno 7] Argument list too long: 'firefox'
```
At least two other devs on rebble discord say they have run into this and work around it by temporarily commenting out parts of their config page.

[A PR was raised in 2016 to fix it and never merged](https://github.com/pebble/pebble-tool/pull/46); credit to @gregoiresage

This PR is based on that original PR, but updated for python3.



Full original error:
```
ajh@ubuntu24:~/pebble/InstantTimer$ pebble emu-app-config --emulator emery
Traceback (most recent call last):
  File "/home/ajh/.local/bin/pebble", line 10, in <module>
    sys.exit(run_tool())
             ~~~~~~~~^^
  File "/home/ajh/.local/share/uv/tools/pebble-tool/lib/python3.13/site-packages/pebble_tool/__init__.py", line 59, in run_tool
    args.func(args)
    ~~~~~~~~~^^^^^^
  File "/home/ajh/.local/share/uv/tools/pebble-tool/lib/python3.13/site-packages/pebble_tool/commands/base.py", line 47, in <lambda>
    parser.set_defaults(func=lambda x: cls()(x))
                                       ~~~~~^^^
  File "/home/ajh/.local/share/uv/tools/pebble-tool/lib/python3.13/site-packages/pebble_tool/commands/emucontrol.py", line 125, in __call__
    browser.open_config_page(config_url, self.handle_config_close)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/tools/pebble-tool/lib/python3.13/site-packages/pebble_tool/util/browser.py", line 29, in open_config_page
    webbrowser.open_new(url)
    ~~~~~~~~~~~~~~~~~~~^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/webbrowser.py", line 104, in open_new
    return open(url, 1)
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/webbrowser.py", line 94, in open
    if browser.open(url, new, autoraise):
       ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/webbrowser.py", line 286, in open
    success = self._invoke(args, True, autoraise, url)
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/webbrowser.py", line 248, in _invoke
    p = subprocess.Popen(cmdline, close_fds=True, stdin=inout,
                         stdout=(self.redirect_stdout and inout or None),
                         stderr=inout, start_new_session=True)
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/subprocess.py", line 1039, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                        pass_fds, cwd, env,
                        ^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
                        gid, gids, uid, umask,
                        ^^^^^^^^^^^^^^^^^^^^^^
                        start_new_session, process_group)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ajh/.local/share/uv/python/cpython-3.13.12-linux-x86_64-gnu/lib/python3.13/subprocess.py", line 1991, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
OSError: [Errno 7] Argument list too long: 'firefox'
```