### PR TITLE
browser: Send files in binary

### DIFF
--- a/pebble_tool/util/browser.py
+++ b/pebble_tool/util/browser.py
@@ -107,10 +107,10 @@ class BrowserController(object):
                                                              websocket_port="'{}'".format(pypkjs_port)).encode())
                 elif file_path in self.PERMITTED_PATHS:
                     try:
-                        file_contents = open(os.path.join(os.path.dirname(os.path.realpath(__file__)), file_path))
+                        file_contents = open(os.path.join(os.path.dirname(os.path.realpath(__file__)), file_path), 'rb')
                         self.send_response(200)
                         self.end_headers()
-                        self.wfile.write(file_contents.read().encode())
+                        self.wfile.write(file_contents.read())
                     except IOError:
                         self.send_response(404)
                         self.end_headers()


### PR DESCRIPTION
Files -- such as the compass rose for `pebble emu-control` -- were opened in platform encoding (the default for `open()`), and then encoded to UTF-8 (the default for `str.encode()`).

For ASCII files this mostly works, since most encodings are ASCII-compatible. For UTF-8 files it would show garbled characters if the platform encoding isn't UTF-8 (i.e. Windows).
But it breaks on binary files, such as the compass rose, with:
  UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte

Instead of auto-decoding to and re-encoding to bytes, open the file in binary mode (`rb`), and send the bytes.