### PR TITLE
Fix and improve emu-app-config support for purely-data-URI config pages

### DIFF
--- a/pebble_tool/util/browser.py
+++ b/pebble_tool/util/browser.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import os
 import socket
+import sys
 import tempfile
 import time
 from urllib.request import urlopen
@@ -28,7 +29,10 @@ class BrowserController(object):
         # where the config page should send submitted form data
         return_url = 'http://localhost:{}/close?'.format(port)
 
-        if url.startswith('file:'):
+        # NamedTemporaryFile's delete_on_close parameter is only available since python3.12
+        is_tempfile_delete_on_close_available = sys.version_info >= (3, 12)
+
+        if url.startswith('file:') or not is_tempfile_delete_on_close_available:
             # TODO: several browsers strip searchParams when opening local file URLs, so this may not work
             url = self.url_append_params(url, {'return_to': return_url})
 

--- a/pebble_tool/util/browser.py
+++ b/pebble_tool/util/browser.py
@@ -6,6 +6,7 @@ import os
 import socket
 import tempfile
 import time
+from urllib.request import urlopen
 import webbrowser
 
 import pyqrcode
@@ -23,24 +24,46 @@ class BrowserController(object):
 
     def open_config_page(self, url, callback):
         self.port = port = self._choose_port()
-        url = self.url_append_params(url, {'return_to': 'http://localhost:{}/close?'.format(port)})
 
-        if url.startswith('file'):
+        # where the config page should send submitted form data
+        return_url = 'http://localhost:{}/close?'.format(port)
+
+        if url.startswith('file:'):
+            # TODO: several browsers strip searchParams when opening local file URLs, so this may not work
+            url = self.url_append_params(url, {'return_to': return_url})
+
             webbrowser.open_new(url)
             self.serve_page(port, callback)
         else:
-            # The URL argument length limit can quickly be exceeded by a Clay config page
-            # so instead of providing the URL directly, write it to a temporary file.
+            # Firefox's URL argument length limit can quickly be exceeded by a Clay config URL
+            # and many browsers have trouble directly opening data URIs for a fully local config page.
+            # So instead of opening the URL directly, write it to a temporary file.
             # Default Ubuntu firefox installation can't access /tmp
             # so place the temporary file in the user's home directory.
             with tempfile.NamedTemporaryFile(dir=os.path.expanduser("~"),
                                              delete_on_close=False,
                                              prefix="pebble-tool-emu-app-config-",
                                              suffix=".html") as temp:
-                with open(temp.name, mode="w") as f:
-                    f.write(f'<head><meta http-equiv="refresh" content="0;URL={url}"></head>')
-                tempfile_url = f"file://{temp.name}"
 
+                if url.startswith('data:'):  # a data URI encoding the config page's HTML
+                    # decode the data URI and write the resulting HTML
+                    with urlopen(url) as response:
+                        data = response.read()
+                        # several browsers strip searchParams when opening local file URLs
+                        # so append to the HTML a script to self-refresh with added searchParam
+                        data += (f'<script>if(!location.search){{location.search="?return_to={return_url}"}}</script>'
+                                 .encode("utf-8"))
+                        with open(temp.name, mode="wb") as f:
+                            f.write(data)
+
+                else:  # an HTTP URL. This is the path that web-hosted and Clay configs take.
+                    # several browsers strip searchParams when opening local file URLs
+                    # so write an HTML page which self-refreshes into the url with added searchParam
+                    url = self.url_append_params(url, {'return_to': return_url})
+                    with open(temp.name, mode="w") as f:
+                        f.write(f'<head><meta http-equiv="refresh" content="0;URL={url}"></head>')
+
+                tempfile_url = f"file://{temp.name}"
                 webbrowser.open_new(tempfile_url)
                 self.serve_page(port, callback)
 


### PR DESCRIPTION
Fixes https://github.com/coredevices/pebble-tool/issues/77

Config pages expressed as pure data URIs (such as for freakified's PebbleChecklist) cannot be opened via `meta http-equiv="refresh"` (the new method for opening emu config pages added in https://github.com/coredevices/pebble-tool/pull/67).
They also can't be opened directly (the original method) in some host configurations (e.g. Ubuntu/Firefox).
Opening directly would mostly work in MacOS, but with some warnings raised and odd behaviour where the URL searchParam string would be appended to the HTML itself.

This PR doesn't change the behaviour for file URLs, web-hosted config pages or Clay config pages.
This PR adds a new path to open purely local data URIs while validly applying the return_to searchParam.

I've tested this works on Ubuntu/Firefox, with both https://github.com/freakified/PebbleChecklist (which has a pure-data-URI config page) and https://github.com/howeaj/pebble-instant-timer (which has a large Clay config page)

@tilden please test on your MacOS all-browsers setup too