### PR TITLE
publish: add --replace-screenshots flag (#79)

### DIFF
--- a/pebble_tool/commands/publish.py
+++ b/pebble_tool/commands/publish.py
@@ -169,6 +169,7 @@ class PublishCommand(BaseCommand):
             if app_id:
                 self._ok("Resolved existing appstore app ID: {}".format(app_id))
                 gif_paths, screenshot_paths = self._collect_screenshot_assets(args, pbw_metadata, allow_skip=True)
+                self._gate_replace_screenshots(args, gif_paths, screenshot_paths)
                 self._step("Publishing release to Pebble Appstore...")
                 response_payload = self._upload_release(
                     api_base=args.api_base,
@@ -180,6 +181,7 @@ class PublishCommand(BaseCommand):
                     is_published=args.is_published,
                     gif_paths=gif_paths,
                     screenshot_paths=screenshot_paths,
+                    replace_screenshots=getattr(args, "replace_screenshots", False),
                 )
                 resolved_app_id = app_id
             else:
@@ -505,6 +507,26 @@ class PublishCommand(BaseCommand):
         error_text = (payload.get("error") or response.text or "").lower()
         return "screenshot" in error_text
 
+    def _gate_replace_screenshots(self, args, gif_paths, screenshot_paths):
+        # Guard + destructive-action confirmation for --replace-screenshots.
+        # Replacement is irreversible via the CLI, so fail closed when there is
+        # nothing to upload and require explicit confirmation on an interactive TTY.
+        if not getattr(args, "replace_screenshots", False):
+            return
+        if not (gif_paths or screenshot_paths):
+            raise ToolError("--replace-screenshots requires screenshots to upload")
+        count = len(gif_paths) + len(screenshot_paths)
+        if getattr(args, "non_interactive", False):
+            # In --non-interactive (CI) mode the flag itself is the consent.
+            return
+        self._warn(
+            "About to REPLACE the app's existing screenshots with {} uploaded file(s). "
+            "This cannot be undone via the CLI.".format(count)
+        )
+        answer = input("Replace existing screenshots? [y/N]: ").strip().lower()
+        if answer not in ("y", "yes"):
+            raise ToolError("Aborted: screenshot replacement not confirmed.")
+
     @classmethod
     def _upload_release(
         cls,
@@ -517,13 +539,14 @@ class PublishCommand(BaseCommand):
         is_published,
         gif_paths,
         screenshot_paths,
+        replace_screenshots=False,
     ):
         url = "{}/api/dashboard/apps/{}/releases".format(api_base.rstrip("/"), app_id)
         form_data = {
             "version": version,
             "releaseNotes": release_notes or "",
             "isPublished": "true",
-            "replaceScreenshots": "false",
+            "replaceScreenshots": "true" if replace_screenshots else "false",
         }
 
         files_payload = []
@@ -586,6 +609,7 @@ class PublishCommand(BaseCommand):
                     release_notes=release_notes,
                     is_published=is_published,
                     gif_paths=[], screenshot_paths=[],
+                    replace_screenshots=False,
                 )
             raise ToolError(
                 "Release upload failed ({}): {}".format(
@@ -993,4 +1017,8 @@ class PublishCommand(BaseCommand):
         parser.add_argument("--screenshots", nargs="+", default=None, metavar="FILE",
                             help="Local screenshot/GIF files to upload in --non-interactive mode. "
                                  "Filenames must start with the platform name, e.g. emery_screenshot.png.")
+        parser.add_argument("--replace-screenshots", action="store_true", default=False,
+                            help="Replace the app's existing screenshots with the uploaded ones "
+                                 "instead of appending (existing apps only). Irreversible via the "
+                                 "CLI; prompts for confirmation unless --non-interactive.")
         return parser

--- a/tests/test_publish_command.py
+++ b/tests/test_publish_command.py
@@ -201,3 +201,113 @@ def test_collect_new_app_details_non_interactive_requires_description():
             {"app_name": "App", "version": "1.0", "app_type": "watchapp"},
             {},
         )
+
+
+# --- Feature A: --replace-screenshots (#79) ---
+
+
+def test_publish_parser_has_replace_screenshots_default_false():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    PublishCommand.add_parser(subparsers)
+    ns = parser.parse_args(["publish"])
+    assert ns.replace_screenshots is False
+
+
+def test_upload_release_sends_replace_screenshots_false_by_default(monkeypatch, tmp_path):
+    pbw = tmp_path / "app.pbw"
+    pbw.write_bytes(b"pbw")
+    shot = tmp_path / "emery_1.png"
+    shot.write_bytes(b"img")
+
+    captured = {}
+
+    def fake_post(cls, url, headers, data, files, timeout, label):
+        captured["data"] = dict(data)
+        return _FakeResponse({"message": "ok"}, status_code=200)
+
+    monkeypatch.setattr(PublishCommand, "_post_with_wait_bar", classmethod(fake_post))
+
+    PublishCommand._upload_release(
+        api_base="http://localhost:3000",
+        app_id="app_1",
+        firebase_id_token="tok",
+        pbw_path=str(pbw),
+        version="1.0",
+        release_notes="",
+        is_published=False,
+        gif_paths=[],
+        screenshot_paths=[str(shot)],
+    )
+    assert captured["data"]["replaceScreenshots"] == "false"
+
+
+def test_upload_release_sends_replace_screenshots_true_when_flag_set(monkeypatch, tmp_path):
+    pbw = tmp_path / "app.pbw"
+    pbw.write_bytes(b"pbw")
+    shot = tmp_path / "emery_1.png"
+    shot.write_bytes(b"img")
+
+    captured = {}
+
+    def fake_post(cls, url, headers, data, files, timeout, label):
+        captured["data"] = dict(data)
+        return _FakeResponse({"message": "ok"}, status_code=200)
+
+    monkeypatch.setattr(PublishCommand, "_post_with_wait_bar", classmethod(fake_post))
+
+    PublishCommand._upload_release(
+        api_base="http://localhost:3000",
+        app_id="app_1",
+        firebase_id_token="tok",
+        pbw_path=str(pbw),
+        version="1.0",
+        release_notes="",
+        is_published=False,
+        gif_paths=[],
+        screenshot_paths=[str(shot)],
+        replace_screenshots=True,
+    )
+    assert captured["data"]["replaceScreenshots"] == "true"
+
+
+def test_replace_screenshots_without_screenshots_raises():
+    args = Namespace(replace_screenshots=True, non_interactive=True)
+    cmd = PublishCommand()
+    with pytest.raises(ToolError, match="requires screenshots"):
+        cmd._gate_replace_screenshots(args, [], [])
+
+
+def test_screenshot_retry_path_never_sends_replace_true(monkeypatch, tmp_path):
+    pbw = tmp_path / "app.pbw"
+    pbw.write_bytes(b"pbw")
+    shot = tmp_path / "emery_1.png"
+    shot.write_bytes(b"img")
+
+    calls = []
+
+    def fake_post(cls, url, headers, data, files, timeout, label):
+        calls.append(dict(data))
+        if len(calls) == 1:
+            return _FakeResponse({"error": "invalid screenshot"}, status_code=400)
+        return _FakeResponse({"message": "ok"}, status_code=200)
+
+    monkeypatch.setattr(PublishCommand, "_post_with_wait_bar", classmethod(fake_post))
+
+    PublishCommand._upload_release(
+        api_base="http://localhost:3000",
+        app_id="app_1",
+        firebase_id_token="tok",
+        pbw_path=str(pbw),
+        version="1.0",
+        release_notes="",
+        is_published=False,
+        gif_paths=[],
+        screenshot_paths=[str(shot)],
+        replace_screenshots=True,
+    )
+    assert len(calls) == 2
+    assert calls[0]["replaceScreenshots"] == "true"
+    assert calls[1]["replaceScreenshots"] == "false"


### PR DESCRIPTION
Partially addresses #79 (the screenshot half — see the issue comment for the metadata half).

## Problem

On an existing app, `--screenshots` only ever appends — screenshots pile up across releases (I got to 11 on two of my watchfaces). The only remedy today is the web dashboard.

## What this PR does

Adds an opt-in `--replace-screenshots` flag to `pebble publish`. The backend already supports replacement: the release endpoint accepts a `replaceScreenshots` form field, which the CLI currently hardcodes to `"false"` (`_upload_release`). This exposes it.

Validated against production on two apps: with the flag, the app's existing screenshot set was fully replaced by the uploaded set (before/after asset URLs share zero entries). Both test apps are single-platform, so the help text claims "replaces existing screenshots" without promising per-platform granularity on multi-platform apps.

Safety rails:
- Passing the flag with no screenshots to upload is an error (fail-closed — replace+empty could otherwise wipe a listing).
- The screenshot-validation retry path (400 → retry without screenshots) always re-sends `"false"`, so a degraded retry can never wipe existing screenshots.
- Interactive runs get a `[y/N]` confirmation (replacement is irreversible via CLI); `--non-interactive` skips it — the flag itself is the consent.

## Backward compatibility

No behavior change without the flag: the release upload sends `replaceScreenshots=false` exactly as before, byte-for-byte identical form data. All 65 pre-existing tests pass unmodified.

## Tests

5 new tests in `tests/test_publish_command.py`, following the existing monkeypatch/`_FakeResponse` pattern: flag default, plumb-through false/true, fail-closed guard, retry-path safety. Full suite green: `uv run pytest tests/ -q` → 75 passed.

## Out of scope / noticed while here

- The metadata-update half of #79: implemented and working CLI-side (`app-update` command, kept on a branch), but `PATCH /api/dashboard/apps/{id}` returns 401 to developer Firebase Bearer tokens that the sibling POST endpoints accept — details + evidence in the issue comment. Happy to send the follow-up PR if Bearer auth gets enabled on that route.
- `--is-published` is documented as "default: false" but `_upload_release` and `_create_app` hardcode `"isPublished": "true"`, so the flag is a no-op. Fixing it changes default behavior — separate one-line PR if you confirm the intended default.
- Individual screenshot delete/reorder: no dedicated backend endpoint exists; stays dashboard-only.
