### PR TITLE
screenshot: don't press BACK during GIF capture; fix watchapp recording

### DIFF
--- a/pebble_tool/commands/screenshot.py
+++ b/pebble_tool/commands/screenshot.py
@@ -11,7 +11,6 @@ import png
 import os.path
 import re
 import socket
-import threading
 from progressbar import ProgressBar, Bar, ReverseBar, FileTransferSpeed, Timer, Percentage
 import signal
 import subprocess
@@ -179,37 +178,29 @@ class ScreenshotCommand(PebbleCommand):
         if not monitor_port:
             raise ToolError("QEMU monitor port not available; cannot capture GIF.")
 
-        # Start the backlight keepalive *before* the minute-boundary wait so
-        # the screen is already lit by the time we start recording. The Pebble
-        # backlight times out after a few seconds, so a single tap up front
-        # would go dark again during the up-to-60s wait.
-        stop_keepalive = threading.Event()
-
-        def backlight_keepalive():
-            while not stop_keepalive.wait(1.0):
-                self._qemu_monitor_command(monitor_port, "sendkey left")
-
-        # Initial tap so the backlight is on right now; the keepalive thread
-        # then refreshes it every second.
-        self._qemu_monitor_command(monitor_port, "sendkey left")
-        keepalive_thread = threading.Thread(target=backlight_keepalive, daemon=True)
-        keepalive_thread.start()
+        # Do NOT inject any input to keep the backlight on. The old approach
+        # ("sendkey left" every second) presses the BACK button, which
+        # watchfaces ignore but watchapps act on — a BACK press per second
+        # exits any watchapp before the GIF can be captured, and no button
+        # is semantically safe for an arbitrary app (up/down/select all do
+        # things). QemuTap does not trigger tap-to-light in the emulator
+        # firmware. Instead we deliberately record the UNLIT panel — a flat
+        # ~39% brightness scale — and normalize brightness in the ffmpeg
+        # pass below, which is lossless and identical for faces and apps.
 
         # Wait so the recording window straddles the next minute boundary,
-        # putting the rollover ~3 s into the 7 s clip.
+        # putting the rollover ~3 s into the 7 s clip. Enforce a minimum
+        # wait so any backlight lit by the install has fully timed out and
+        # every frame is uniformly unlit.
         pre_rollover = 3.0
+        min_wait = 8.0
         now = time.time()
         wait_seconds = (60 - (now % 60)) - pre_rollover
-        if wait_seconds < 0:
+        if wait_seconds < min_wait:
             wait_seconds += 60
         print("Waiting {:.1f}s for next minute boundary, then capturing {}s...".format(
             wait_seconds, duration_seconds))
         time.sleep(wait_seconds)
-
-        # Refresh the backlight one more time and give it a moment to settle
-        # in the framebuffer before the first frame is dumped.
-        self._qemu_monitor_command(monitor_port, "sendkey left")
-        time.sleep(0.3)
 
         temp_dir = tempfile.mkdtemp(prefix="pebble-gif-")
         frame_paths = []
@@ -243,9 +234,6 @@ class ScreenshotCommand(PebbleCommand):
                 next_capture += frame_interval
                 frame_index += 1
 
-            stop_keepalive.set()
-            keepalive_thread.join(timeout=3.0)
-
             if not frame_paths:
                 raise ToolError("No frames captured for GIF.")
 
@@ -262,24 +250,38 @@ class ScreenshotCommand(PebbleCommand):
             if output_dir:
                 os.makedirs(output_dir, exist_ok=True)
 
+            # The panel was recorded unlit (see note above): a flat linear
+            # brightness scale. Measure the actual peak and normalize back
+            # to full brightness in the ffmpeg pass. Skip if frames are
+            # already (near-)fully lit.
+            peak = 0
+            for idx in range(0, len(frame_paths), max(1, len(frame_paths) // 8)):
+                p = os.path.join(seq_dir, "frame_{:05d}.ppm".format(idx))
+                img = Image.open(p).convert("RGB")
+                peak = max(peak, max(e[1] for e in img.getextrema()))
+                img.close()
+            if 0 < peak < 250:
+                gain = 'lutrgb=r=clip(val*255/{0}\\,0\\,255):g=clip(val*255/{0}\\,0\\,255):b=clip(val*255/{0}\\,0\\,255),'.format(peak)
+            else:
+                gain = ''
+
             print("Processing {} frames into GIF...".format(len(frame_paths)))
             palette = os.path.join(temp_dir, "palette.png")
             self._run_ffmpeg([
                 'ffmpeg', '-framerate', str(target_fps), '-i', seq_pattern,
-                '-vf', 'palettegen=max_colors=64:reserve_transparent=0',
+                '-vf', '{}palettegen=max_colors=64:reserve_transparent=0'.format(gain),
                 '-y', palette, '-v', 'error',
             ], "Palette generation")
 
             self._run_ffmpeg([
                 'ffmpeg', '-framerate', str(target_fps), '-i', seq_pattern,
                 '-i', palette,
-                '-filter_complex', '[0:v]mpdecimate[v];[v][1:v]paletteuse=dither=none',
+                '-filter_complex', '[0:v]{}mpdecimate[v];[v][1:v]paletteuse=dither=none'.format(gain),
                 '-y', filename, '-v', 'error',
             ], "GIF encoding")
 
             print("Saved rollover GIF to {}".format(filename))
         finally:
-            stop_keepalive.set()
             shutil.rmtree(temp_dir, ignore_errors=True)
 
     def _capture_gif_all_platforms(self, args):


### PR DESCRIPTION
Fixes #75.

## Problem

`_capture_rollover_gif` keeps the backlight on with a keepalive thread that sends `sendkey left` to the QEMU monitor every second — and left arrow maps to the **BACK button**. Watchfaces ignore BACK, but watchapps act on it: any watchapp is exited within a second of capture starting, so `pebble screenshot --gif-all-platforms` (and the GIF step of `pebble publish`) can only record watchfaces. This is exactly the behavior reported in #75, and apps that guard BACK with an exit-confirmation still die because the presses arrive 1s apart.

## Why not just use a different input

- **Another button**: none is semantically safe for an arbitrary watchapp — UP/DOWN/SELECT all trigger app actions.
- **Accelerometer tap** (`QemuTap`, hoping for tap-to-light): measured in the emery emulator — a tap does not wake the backlight (screendump peak stays at 100/255), while a button press does (255/255). So tap-to-light isn't available in the emulator firmware.

## Fix

Inject **no input at all** and record the unlit panel. The unlit LCD renders as an exact linear brightness scale (measured channel levels 0/33/66/100 instead of 0/85/170/255, i.e. ~39%). The patch:

1. removes the keepalive entirely;
2. enforces a minimum pre-capture wait so any backlight lit by the app install has fully timed out (frames are uniformly unlit);
3. measures the actual peak across sampled frames and normalizes brightness in the existing ffmpeg pass via `lutrgb` (`val*255/peak`), applied to both the palettegen and paletteuse runs. The correction is lossless (0/33/66/100 → 0/84/168/255) and skipped when frames are already lit (peak ≥ 250), so behavior is unchanged for any setup where the panel is lit by other means.

## Verification

Tested on macOS with SDK 4.17, emery emulator, and a watchapp (a metronome):

- **Before**: capture presses BACK once per second → app exits → GIF shows the launcher/watchface.
- **After**: GIF shows the running watchapp in every frame, output peak brightness 255, colors correct (verified by extracting frames with ffmpeg and measuring channel extrema with PIL).

Watchface rollover GIFs still work — the minute-boundary logic is untouched aside from the minimum wait, which can add up to one extra minute before capture when the boundary is too close.

No overlap with #80 (touches only `publish.py`).