### PR TITLE
screenshot: recover GIF brightness with exact per-platform unlit→lit LUTs

### DIFF
--- a/pebble_tool/commands/screenshot.py
+++ b/pebble_tool/commands/screenshot.py
@@ -185,8 +185,8 @@ class ScreenshotCommand(PebbleCommand):
         # is semantically safe for an arbitrary app (up/down/select all do
         # things). QemuTap does not trigger tap-to-light in the emulator
         # firmware. Instead we deliberately record the UNLIT panel — a flat
-        # ~39% brightness scale — and normalize brightness in the ffmpeg
-        # pass below, which is lossless and identical for faces and apps.
+        # per-platform brightness scale — and normalize brightness in the
+        # ffmpeg pass below, which is lossless and identical for faces and apps.
 
         # Wait so the recording window straddles the next minute boundary,
         # putting the rollover ~3 s into the 7 s clip. Enforce a minimum
@@ -250,18 +250,31 @@ class ScreenshotCommand(PebbleCommand):
             if output_dir:
                 os.makedirs(output_dir, exist_ok=True)
 
-            # The panel was recorded unlit (see note above): a flat linear
-            # brightness scale. Measure the actual peak and normalize back
-            # to full brightness in the ffmpeg pass. Skip if frames are
-            # already (near-)fully lit.
-            peak = 0
-            for idx in range(0, len(frame_paths), max(1, len(frame_paths) // 8)):
-                p = os.path.join(seq_dir, "frame_{:05d}.ppm".format(idx))
-                img = Image.open(p).convert("RGB")
-                peak = max(peak, max(e[1] for e in img.getextrema()))
-                img.close()
-            if 0 < peak < 250:
-                gain = 'lutrgb=r=clip(val*255/{0}\\,0\\,255):g=clip(val*255/{0}\\,0\\,255):b=clip(val*255/{0}\\,0\\,255),'.format(peak)
+            # The panel was recorded unlit (see note above): with the backlight
+            # off the emulator scales the lit channel values {85, 170, 255} down
+            # to a per-platform unlit set (measured from QEMU screendumps of the
+            # same screen lit vs backlight timed out). The two sets are disjoint,
+            # so mapping unlit values back to lit is exact AND identity on lit
+            # pixels: every frame is corrected independently, and frames where
+            # the backlight happened to be on (e.g. apps calling
+            # light_enable(true), or a mid-clip backlight change) pass through
+            # untouched -- no guessing from content brightness.
+            # Basalt and chalk get no correction and stay dim
+            # rather than risk corrupted colours: basalt's legacy renderer puts
+            # unlit 170 one step from lit 169, and chalk renders continuous
+            # antialiased values, so no safe exact mapping exists for either.
+            unlit_to_lit = {
+                'aplite': {170: 254},
+                'diorite': {170: 226},
+                'emery': {33: 85, 66: 170, 100: 255},
+                'flint': {180: 255},
+                'gabbro': {60: 85, 120: 170, 180: 255},
+            }.get(self.pebble.watch_platform)
+            if unlit_to_lit:
+                expr = 'val'
+                for unlit, lit in unlit_to_lit.items():
+                    expr = 'if(eq(val\\,{0})\\,{1}\\,{2})'.format(unlit, lit, expr)
+                gain = 'lutrgb=r={0}:g={0}:b={0},'.format(expr)
             else:
                 gain = ''
 


### PR DESCRIPTION
The rollover GIF is recorded with the backlight off (#81 removed input injection during capture, since every button has app semantics). Brightness was recovered with a gain derived from the frames' own peak, gated on `peak < 150`. Both parts were content-dependent and wrong in different ways:

- an app that forces the backlight on but only uses dim colours (brightest channel 85) slips through the gate and gets over-brightened
- the gate never fired on gabbro or flint at all — their unlit peak is 180 — so their GIFs shipped ~30% dim

### Fix

Measured from QEMU screendumps (same screen, backlight lit vs. timed out), the lit and unlit channel values are bit-exact, disjoint sets per platform:

| platform | lit             | unlit           |
| -------- | --------------- | --------------- |
| emery    | 0, 85, 170, 255 | 0, 33, 66, 100  |
| gabbro   | 0, 85, 170, 255 | 0, 60, 120, 180 |
| flint    | 0, 255          | 0, 180          |
| aplite   | 0, 254          | 0, 170          |
| diorite  | 0, 226          | 0, 170          |

Since the sets don't overlap, an exact value LUT (unlit→lit, identity on everything else) replaces the peak scan, the gate, and the gain. It runs unconditionally in the existing ffmpeg pass and corrects every frame independently: lit frames pass through untouched, so apps calling `light_enable(true)` come out unchanged, and a backlight change mid-clip produces identical corrected frames instead of flicker.

basalt and chalk get no correction and stay dim, as before: basalt's legacy renderer puts unlit 170 one step from lit 169 (a one-step drift on another host would corrupt lit pixels), and chalk renders continuous antialiased values, so no safe exact mapping exists for either.

Verified by interleaving lit and unlit screendumps through the exact ffmpeg pipeline: every output frame is pixel-identical to the lit capture (checked on emery, gabbro, aplite, diorite).

This path is used by `pebble screenshot --gif-all-platforms` and by `pebble publish`, which uploads the resulting GIFs directly as store assets — both fully automated, which is why exact per-frame correction beats a heuristic here.
