### PR TITLE
Add adb transport for connected android devices

### DIFF
--- a/pebble_tool/commands/appmessage.py
+++ b/pebble_tool/commands/appmessage.py
@@ -10,7 +10,7 @@ from ..sdk.project import PebbleProject
 class SendAppMessageCommand(PebbleCommand):
     """Sends an App Message key-value dictionary to the running watchapp."""
     command = 'send-app-message'
-    valid_connections = {'emulator', 'qemu', 'phone', 'serial', 'cloudpebble'}
+    valid_connections = {'emulator', 'qemu', 'phone', 'serial', 'cloudpebble', 'adb'}
 
     @classmethod
     def _parse_key_value(cls, entry, flag_name):

--- a/pebble_tool/commands/base.py
+++ b/pebble_tool/commands/base.py
@@ -18,6 +18,7 @@ from pebble_tool.exceptions import ToolError
 from pebble_tool.sdk import get_pebble_platforms, sdk_version
 from pebble_tool.sdk.emulator import ManagedEmulatorTransport, ExternalQemuTransport, get_all_emulator_info
 from pebble_tool.sdk.cloudpebble import CloudPebbleTransport
+from pebble_tool.util import adb
 from pebble_tool.util.analytics import post_event
 
 _CommandRegistry = []
@@ -234,6 +235,30 @@ class PebbleTransportPhone(PebbleTransportConfiguration):
                             help="Connect to your phone. If phone_ip is given, connect directly via "
                                  "WebSocket; otherwise, use the CloudPebble connection. "
                                  "Equivalent to PEBBLE_PHONE.")
+
+
+class PebbleTransportAdb(PebbleTransportConfiguration):
+    transport_class = WebsocketTransport
+    name = 'adb'
+
+    @classmethod
+    def _connect_args(cls, args):
+        serial = getattr(args, cls.name, None) or cls._config_env_var()
+        # PEBBLE_ADB is usually set to a flag-like value just to opt in, rather than to a serial.
+        if serial is True or str(serial).lower() in ('1', 'true', 'yes'):
+            device = []
+        else:
+            device = ['-s', serial]
+        local_port = adb.forward(device, adb.start_dev_connection(device))
+        return ("ws://127.0.0.1:{}/".format(local_port),)
+
+    @classmethod
+    def add_argument_handler(cls, group, parser):
+        group.add_argument('--adb', nargs='?', const=True, metavar='device_serial',
+                           help="Connect to the Pebble app on an Android device over adb, "
+                                "starting its developer connection for you. device_serial "
+                                "picks a device if several are attached. "
+                                "Equivalent to PEBBLE_ADB.")
 
 
 class PebbleTransportQemu(PebbleTransportConfiguration):

--- a/pebble_tool/util/adb.py
+++ b/pebble_tool/util/adb.py
@@ -1,0 +1,68 @@
+__author__ = 'katharine'
+
+import atexit
+import logging
+import re
+import subprocess
+
+from pebble_tool.exceptions import ToolError
+
+ACTION = 'coredevices.coreapp.DEV_CONNECTION'
+COMPONENT = 'coredevices.coreapp/coredevices.coreapp.debug.DevConnectionReceiver'
+
+_RESULT_RE = re.compile(r'result=(-?\d+)(?:, data="(.*?)")?', re.DOTALL)
+_PORT_RE = re.compile(r'^\s*(\d+)\s*$', re.MULTILINE)
+
+logger = logging.getLogger("pebble_tool.util.adb")
+
+
+def _adb(device, *args):
+    command = ['adb'] + list(device) + list(args)
+    logger.debug("Running %s", command)
+    try:
+        return subprocess.check_output(command, stderr=subprocess.STDOUT).decode('utf-8', 'replace')
+    except OSError:
+        raise ToolError("Couldn't run adb; make sure the Android platform-tools are installed "
+                        "and adb is on your PATH.")
+    except subprocess.CalledProcessError as e:
+        raise ToolError("adb failed: {}".format(e.output.decode('utf-8', 'replace').strip()))
+
+
+def start_dev_connection(device):
+    """Ask the Pebble app to start its LAN dev connection; returns the port it's listening on."""
+    output = _adb(device, 'shell', 'am', 'broadcast', '-a', ACTION, '-n', COMPONENT)
+    match = _RESULT_RE.search(output)
+    if match is None:
+        raise ToolError("Couldn't understand the response from the Pebble app: {}".format(output.strip()))
+
+    code, data = match.group(1), match.group(2)
+    if code != '0':
+        raise ToolError("The Pebble app couldn't start a developer connection: {}"
+                        .format(data or "error {}".format(code)))
+    # An unhandled broadcast also reports result=0, so the absence of result data means nothing
+    # received it.
+    if not data:
+        raise ToolError("The Pebble app didn't respond to the developer connection broadcast. "
+                        "Make sure it's installed and up to date.")
+    try:
+        return int(data)
+    except ValueError:
+        raise ToolError("The Pebble app reported an invalid port: {!r}".format(data))
+
+
+def forward(device, port):
+    """Tunnel a port on this machine through to `port` on the device; returns the local port."""
+    output = _adb(device, 'forward', 'tcp:0', 'tcp:{}'.format(port))
+    match = _PORT_RE.search(output)
+    if match is None:
+        raise ToolError("Couldn't work out which port adb forwarded: {}".format(output.strip()))
+    local_port = int(match.group(1))
+    atexit.register(_remove_forward, device, local_port)
+    return local_port
+
+
+def _remove_forward(device, local_port):
+    try:
+        _adb(device, 'forward', '--remove', 'tcp:{}'.format(local_port))
+    except ToolError:
+        pass

--- a/tests/test_adb_transport.py
+++ b/tests/test_adb_transport.py
@@ -1,0 +1,88 @@
+"""
+Tests for the adb transport helpers.
+"""
+from __future__ import annotations
+
+import subprocess
+from unittest import mock
+
+import pytest
+
+from pebble_tool.exceptions import ToolError
+from pebble_tool.util import adb
+
+
+def _adb_returning(output):
+    return mock.patch.object(adb, '_adb', return_value=output)
+
+
+class TestStartDevConnection:
+    def test_returns_port(self):
+        with _adb_returning('Broadcasting: Intent { act=... }\n'
+                            'Broadcast completed: result=0, data="9000"\n'):
+            assert adb.start_dev_connection([]) == 9000
+
+    def test_no_data_means_nothing_received_it(self):
+        # An unhandled broadcast also reports result=0, so missing data is how we spot an app
+        # without the receiver.
+        with _adb_returning('Broadcast completed: result=0\n'):
+            with pytest.raises(ToolError, match="didn't respond"):
+                adb.start_dev_connection([])
+
+    def test_failure_surfaces_app_message(self):
+        with _adb_returning('Broadcast completed: result=1, data="no watch connected"\n'):
+            with pytest.raises(ToolError, match="no watch connected"):
+                adb.start_dev_connection([])
+
+    def test_failure_without_message(self):
+        with _adb_returning('Broadcast completed: result=2\n'):
+            with pytest.raises(ToolError, match="error 2"):
+                adb.start_dev_connection([])
+
+    def test_unparseable_output(self):
+        with _adb_returning('something else entirely\n'):
+            with pytest.raises(ToolError, match="Couldn't understand"):
+                adb.start_dev_connection([])
+
+    def test_non_numeric_port(self):
+        with _adb_returning('Broadcast completed: result=0, data="banana"\n'):
+            with pytest.raises(ToolError, match="invalid port"):
+                adb.start_dev_connection([])
+
+    def test_passes_device_flag_through(self):
+        with mock.patch.object(adb, '_adb',
+                               return_value='Broadcast completed: result=0, data="9000"') as m:
+            adb.start_dev_connection(['-s', 'ABC123'])
+        assert m.call_args[0][0] == ['-s', 'ABC123']
+        assert 'am' in m.call_args[0]
+
+
+class TestForward:
+    def test_returns_local_port(self):
+        with _adb_returning('41234\n'):
+            with mock.patch.object(adb, 'atexit'):
+                assert adb.forward([], 9000) == 41234
+
+    def test_registers_cleanup(self):
+        with _adb_returning('41234\n'):
+            with mock.patch.object(adb, 'atexit') as at:
+                adb.forward([], 9000)
+        at.register.assert_called_once_with(adb._remove_forward, [], 41234)
+
+    def test_unparseable_output(self):
+        with _adb_returning('error: no devices/emulators found\n'):
+            with pytest.raises(ToolError, match="which port"):
+                adb.forward([], 9000)
+
+
+class TestAdbInvocation:
+    def test_missing_binary(self):
+        with mock.patch('subprocess.check_output', side_effect=OSError):
+            with pytest.raises(ToolError, match="on your PATH"):
+                adb._adb([], 'devices')
+
+    def test_command_failure_includes_output(self):
+        error = subprocess.CalledProcessError(1, 'adb', output=b'device unauthorized')
+        with mock.patch('subprocess.check_output', side_effect=error):
+            with pytest.raises(ToolError, match="device unauthorized"):
+                adb._adb([], 'devices')

--- a/uv.lock
+++ b/uv.lock
@@ -401,7 +401,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -822,7 +822,7 @@ wheels = [
 
 [[package]]
 name = "pebble-tool"
-version = "5.0.37"
+version = "5.0.39"
 source = { editable = "." }
 dependencies = [
     { name = "cobs" },


### PR DESCRIPTION
Avoids needing to manually enable server in the app, or note down the IP address when a phone is connected via adb.

This will poke the phone app to enable the dev connection, forward that socket to this machine, and continue directly (i.e. just make it work).

Phone app changes will likely go out in 1.10.x